### PR TITLE
idk i tried to fix the logo looking small but it didn't work

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2089,6 +2089,10 @@ ul.social li a.fa-google-plus:hover {
     width: 100%;
 }
 
+/* this is to override bootstrap's font-weight: 700 !important that makes the logo small on firefox */
+#override-bootstrap {
+    font-weight: 0;
+}
 
 .navbar-item {
     width: 150%

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
                     <img src="./images/UB_Horizontal_Small.png">
                 </a>
                 <a class="navbar-brand" href="./">
-                    <img class="img-fluid" style="max-width: 490%; max-height: 190%;" src="./images/yulogo.png">
+                    <img class="img-fluid" style="max-width: 490%; max-height: 190%; font-weight: 0 !important;" src="./images/yulogo.png">
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                     aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
                     <img src="./images/UB_Horizontal_Small.png">
                 </a>
                 <a class="navbar-brand" href="./">
-                    <img class="img-fluid" style="max-width: 490%; max-height: 190%; font-weight: 0 !important;" src="./images/yulogo.png">
+                    <img id="override-bootstrap" class="img-fluid" style="max-width: 490%; max-height: 190%;" src="./images/yulogo.png">
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
                     aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/lablife.html
+++ b/lablife.html
@@ -29,7 +29,7 @@
                     <img src="./images/UB_Horizontal_Small.png">
                 </a>
 				 <a class="navbar-brand" href="index.html">
-                    <img class="img-fluid" style="max-width: 490%; max-height: 190%;" src="./images/yulogo.png">
+                    <img class="img-fluid" style="max-width: 490%; max-height: 190%; font-weight: 0 !important;" src="./images/yulogo.png">
 				 </a>
 				 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
 					  aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">

--- a/lablife.html
+++ b/lablife.html
@@ -29,7 +29,7 @@
                     <img src="./images/UB_Horizontal_Small.png">
                 </a>
 				 <a class="navbar-brand" href="index.html">
-                    <img class="img-fluid" style="max-width: 490%; max-height: 190%; font-weight: 0 !important;" src="./images/yulogo.png">
+                    <img id="override-bootstrap" class="img-fluid" style="max-width: 490%; max-height: 190%;" src="./images/yulogo.png">
 				 </a>
 				 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
 					  aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Bootstrap has the property "font-weight: 700 !important" for .fw-bold in utilities.scss but I don't know how to override it. That is why on firefox, the logo is small on index and lablife pages